### PR TITLE
Update 07example.md to not have presence in the type definitions

### DIFF
--- a/v2-0-RC3/doc/07Examples.md
+++ b/v2-0-RC3/doc/07Examples.md
@@ -41,12 +41,12 @@ Not all FIX enumeration values are listed in the samples.
 			<type name="numVarDataFields" primitiveType="uint16"/>
 		</composite>
 		<composite name="decimalEncoding">
-			<type name="mantissa" presence="optional" primitiveType="int64"/>
-			<type name="exponent" presence="constant" primitiveType="int8">-3</type>
+			<type name="mantissa" primitiveType="int64"/>
+			<type name="exponent" primitiveType="int8">-3</type>
 		</composite>
 		<composite name="qtyEncoding">
 			<type name="mantissa" primitiveType="int32"/>
-			<type name="exponent" presence="constant" primitiveType="int8">0</type>
+			<type name="exponent" primitiveType="int8">0</type>
 		</composite>
 		<composite name="timestampEncoding" description="UTC timestamp with nanosecond precision">
 			<type name="time" primitiveType="uint64"/>


### PR DESCRIPTION
I removed the presence field in the type definitions as they were removed for 2.0 to be field-only (which was a great change).